### PR TITLE
Allow consumers to configure how resources created by the module are named

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,8 @@ The az-backup module resides in the `./infrastructure` sub directory of the repo
 
 In future we will use release tags to ensure consumers can depend on a specific release of the module, however this has not currently been implemented.
 
+The module will create a dedicated resource group to contain the backup vault, therefore the resource group name provided to the module must be unique within the scope of the subscription.
+
 ## Example
 
 The following is an example of how the module should be used:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,9 +17,10 @@ The following is an example of how the module should be used:
 ```terraform
 module "my_backup" {
   source                     = "github.com/nhsdigital/az-backup//infrastructure"
-  vault_name                 = "myvault"
-  vault_location             = "uksouth"
-  vault_redundancy           = "LocallyRedundant"
+  resource_group_name        = "rg-mybackup"
+  resource_group_location    = "uksouth"
+  backup_vault_name          = "bvault-mybackup"
+  backup_vault_redundancy    = "LocallyRedundant"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.my_workspace.id
   blob_storage_backups = {
     backup1 = {
@@ -90,9 +91,10 @@ To deploy the module an Azure identity (typically an app registration with clien
 
 | Name | Description | Mandatory | Default |
 |------|-------------|-----------|---------|
-| `vault_name` | The name of the backup vault. The value supplied will be automatically prefixed with `rg-nhsbackup-`. If more than one az-backup module is created, this value must be unique across them. | Yes | n/a |
-| `vault_location` | The location of the resource group that is created to contain the vault. | No | `uksouth` |
-| `vault_redundancy` | The redundancy of the vault, e.g. `GeoRedundant`. [See the following link for the possible values](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/data_protection_backup_vault#redundancy) | No | `LocallyRedundant` |
+| `resource_group_name` | The name of the resource group that is created to contain the vault. | Yes | n/a |
+| `resource_group_location` | The location of the resource group that is created to contain the vault. | No | `uksouth` |
+| `backup_vault_name` | The name of the backup vault. The value supplied will be automatically prefixed with `rg-nhsbackup-`. If more than one az-backup module is created, this value must be unique across them. | Yes | n/a |
+| `backup_vault_redundancy` | The redundancy of the vault, e.g. `GeoRedundant`. [See the following link for the possible values](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/data_protection_backup_vault#redundancy) | No | `LocallyRedundant` |
 | `log_analytics_workspace_id` | The id of the log analytics workspace that backup telemetry and diagnostics should be sent to. When no value is provided then diagnostics will not be sent anywhere. | No | n/a |
 | `blob_storage_backups` | A map of blob storage backups that should be created. For each backup the following values should be provided: `storage_account_id`, `backup_name` and `retention_period`. When no value is provided then no backups are created. | No | n/a |
 | `blob_storage_backups.storage_account_id` | The id of the storage account that should be backed up. | Yes | n/a |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,7 +91,7 @@ To deploy the module an Azure identity (typically an app registration with clien
 
 | Name | Description | Mandatory | Default |
 |------|-------------|-----------|---------|
-| `resource_group_name` | The name of the resource group that is created to contain the vault. | Yes | n/a |
+| `resource_group_name` | The name of the resource group that is created to contain the vault - this cannot be an existing resource group. | Yes | n/a |
 | `resource_group_location` | The location of the resource group that is created to contain the vault. | No | `uksouth` |
 | `backup_vault_name` | The name of the backup vault. The value supplied will be automatically prefixed with `rg-nhsbackup-`. If more than one az-backup module is created, this value must be unique across them. | Yes | n/a |
 | `backup_vault_redundancy` | The redundancy of the vault, e.g. `GeoRedundant`. [See the following link for the possible values](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/data_protection_backup_vault#redundancy) | No | `LocallyRedundant` |

--- a/infrastructure/backup_modules.tf
+++ b/infrastructure/backup_modules.tf
@@ -1,41 +1,32 @@
 module "blob_storage_backup" {
   for_each           = var.blob_storage_backups
   source             = "./modules/backup/blob_storage"
-  vault_id           = azurerm_data_protection_backup_vault.backup_vault.id
-  vault_name         = var.vault_name
-  vault_location     = var.vault_location
+  vault              = azurerm_data_protection_backup_vault.backup_vault
   backup_name        = each.value.backup_name
   retention_period   = each.value.retention_period
   storage_account_id = each.value.storage_account_id
-  vault_principal_id = azurerm_data_protection_backup_vault.backup_vault.identity[0].principal_id
 }
 
 module "managed_disk_backup" {
   for_each                          = var.managed_disk_backups
   source                            = "./modules/backup/managed_disk"
-  vault_id                          = azurerm_data_protection_backup_vault.backup_vault.id
-  vault_name                        = var.vault_name
-  vault_location                    = var.vault_location
+  vault                             = azurerm_data_protection_backup_vault.backup_vault
   backup_name                       = each.value.backup_name
   retention_period                  = each.value.retention_period
   backup_intervals                  = each.value.backup_intervals
   managed_disk_id                   = each.value.managed_disk_id
   managed_disk_resource_group       = each.value.managed_disk_resource_group
-  vault_principal_id                = azurerm_data_protection_backup_vault.backup_vault.identity[0].principal_id
   assign_resource_group_level_roles = each.key == keys(var.managed_disk_backups)[0] ? true : false
 }
 
 module "postgresql_flexible_server_backup" {
   for_each                          = var.postgresql_flexible_server_backups
   source                            = "./modules/backup/postgresql_flexible_server"
-  vault_id                          = azurerm_data_protection_backup_vault.backup_vault.id
-  vault_name                        = var.vault_name
-  vault_location                    = var.vault_location
+  vault                             = azurerm_data_protection_backup_vault.backup_vault
   backup_name                       = each.value.backup_name
   retention_period                  = each.value.retention_period
   backup_intervals                  = each.value.backup_intervals
   server_id                         = each.value.server_id
   server_resource_group_id          = each.value.server_resource_group_id
-  vault_principal_id                = azurerm_data_protection_backup_vault.backup_vault.identity[0].principal_id
   assign_resource_group_level_roles = each.key == keys(var.postgresql_flexible_server_backups)[0] ? true : false
 }

--- a/infrastructure/backup_vault.tf
+++ b/infrastructure/backup_vault.tf
@@ -1,9 +1,9 @@
 resource "azurerm_data_protection_backup_vault" "backup_vault" {
-  name                = "bvault-${var.vault_name}"
+  name                = var.backup_vault_name
   resource_group_name = azurerm_resource_group.resource_group.name
-  location            = var.vault_location
+  location            = azurerm_resource_group.resource_group.location
   datastore_type      = "VaultStore"
-  redundancy          = var.vault_redundancy
+  redundancy          = var.backup_vault_redundancy
   soft_delete         = "Off"
   identity {
     type = "SystemAssigned"
@@ -25,7 +25,7 @@ locals {
 
 resource "azurerm_monitor_diagnostic_setting" "backup_vault" {
   count                      = length(var.log_analytics_workspace_id) > 0 ? 1 : 0
-  name                       = "bvault-${var.vault_name}-diagnostic-settings"
+  name                       = "${var.backup_vault_name}-diagnostic-settings"
   target_resource_id         = azurerm_data_protection_backup_vault.backup_vault.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 

--- a/infrastructure/modules/backup/blob_storage/backup_instance.tf
+++ b/infrastructure/modules/backup/blob_storage/backup_instance.tf
@@ -1,13 +1,13 @@
 resource "azurerm_role_assignment" "role_assignment" {
   scope                = var.storage_account_id
   role_definition_name = "Storage Account Backup Contributor"
-  principal_id         = var.vault_principal_id
+  principal_id         = var.vault.identity[0].principal_id
 }
 
 resource "azurerm_data_protection_backup_instance_blob_storage" "backup_instance" {
-  name               = "bkinst-${var.vault_name}-blobstorage-${var.backup_name}"
-  vault_id           = var.vault_id
-  location           = var.vault_location
+  name               = "bkinst-blob-${var.backup_name}"
+  vault_id           = var.vault.id
+  location           = var.vault.location
   storage_account_id = var.storage_account_id
   backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.backup_policy.id
 

--- a/infrastructure/modules/backup/blob_storage/backup_policy.tf
+++ b/infrastructure/modules/backup/blob_storage/backup_policy.tf
@@ -1,5 +1,5 @@
 resource "azurerm_data_protection_backup_policy_blob_storage" "backup_policy" {
-  name                                   = "bkpol-${var.vault_name}-blobstorage-${var.backup_name}"
-  vault_id                               = var.vault_id
+  name                                   = "bkpol-blob-${var.backup_name}"
+  vault_id                               = var.vault.id
   operational_default_retention_duration = var.retention_period
 }

--- a/infrastructure/modules/backup/blob_storage/variables.tf
+++ b/infrastructure/modules/backup/blob_storage/variables.tf
@@ -1,17 +1,5 @@
-variable "vault_id" {
-  type = string
-}
-
-variable "vault_name" {
-  type = string
-}
-
-variable "vault_location" {
-  type = string
-}
-
-variable "vault_principal_id" {
-  type = string
+variable "vault" {
+  type = any
 }
 
 variable "backup_name" {

--- a/infrastructure/modules/backup/managed_disk/backup_instance.tf
+++ b/infrastructure/modules/backup/managed_disk/backup_instance.tf
@@ -2,19 +2,19 @@ resource "azurerm_role_assignment" "role_assignment_snapshot_contributor" {
   count                = var.assign_resource_group_level_roles == true ? 1 : 0
   scope                = var.managed_disk_resource_group.id
   role_definition_name = "Disk Snapshot Contributor"
-  principal_id         = var.vault_principal_id
+  principal_id         = var.vault.identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "role_assignment_backup_reader" {
   scope                = var.managed_disk_id
   role_definition_name = "Disk Backup Reader"
-  principal_id         = var.vault_principal_id
+  principal_id         = var.vault.identity[0].principal_id
 }
 
 resource "azurerm_data_protection_backup_instance_disk" "backup_instance" {
-  name                         = "bkinst-${var.vault_name}-manageddisk-${var.backup_name}"
-  vault_id                     = var.vault_id
-  location                     = var.vault_location
+  name                         = "bkinst-disk-${var.backup_name}"
+  vault_id                     = var.vault.id
+  location                     = var.vault.location
   disk_id                      = var.managed_disk_id
   snapshot_resource_group_name = var.managed_disk_resource_group.name
   backup_policy_id             = azurerm_data_protection_backup_policy_disk.backup_policy.id

--- a/infrastructure/modules/backup/managed_disk/backup_policy.tf
+++ b/infrastructure/modules/backup/managed_disk/backup_policy.tf
@@ -1,6 +1,6 @@
 resource "azurerm_data_protection_backup_policy_disk" "backup_policy" {
-  name                            = "bkpol-${var.vault_name}-manageddisk-${var.backup_name}"
-  vault_id                        = var.vault_id
+  name                            = "bkpol-disk-${var.backup_name}"
+  vault_id                        = var.vault.id
   default_retention_duration      = var.retention_period
   backup_repeating_time_intervals = var.backup_intervals
 }

--- a/infrastructure/modules/backup/managed_disk/variables.tf
+++ b/infrastructure/modules/backup/managed_disk/variables.tf
@@ -1,17 +1,5 @@
-variable "vault_id" {
-  type = string
-}
-
-variable "vault_name" {
-  type = string
-}
-
-variable "vault_location" {
-  type = string
-}
-
-variable "vault_principal_id" {
-  type = string
+variable "vault" {
+  type = any
 }
 
 variable "backup_name" {

--- a/infrastructure/modules/backup/postgresql_flexible_server/backup_instance.tf
+++ b/infrastructure/modules/backup/postgresql_flexible_server/backup_instance.tf
@@ -2,19 +2,19 @@ resource "azurerm_role_assignment" "role_assignment_reader" {
   count                = var.assign_resource_group_level_roles == true ? 1 : 0
   scope                = var.server_resource_group_id
   role_definition_name = "Reader"
-  principal_id         = var.vault_principal_id
+  principal_id         = var.vault.identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "role_assignment_long_term_retention_backup_role" {
   scope                = var.server_id
   role_definition_name = "PostgreSQL Flexible Server Long Term Retention Backup Role"
-  principal_id         = var.vault_principal_id
+  principal_id         = var.vault.identity[0].principal_id
 }
 
 resource "azurerm_data_protection_backup_instance_postgresql_flexible_server" "backup_instance" {
-  name             = "bkinst-${var.vault_name}-pgflexserver-${var.backup_name}"
-  vault_id         = var.vault_id
-  location         = var.vault_location
+  name             = "bkinst-pgflex-${var.backup_name}"
+  vault_id         = var.vault.id
+  location         = var.vault.location
   server_id        = var.server_id
   backup_policy_id = azurerm_data_protection_backup_policy_postgresql_flexible_server.backup_policy.id
 

--- a/infrastructure/modules/backup/postgresql_flexible_server/backup_policy.tf
+++ b/infrastructure/modules/backup/postgresql_flexible_server/backup_policy.tf
@@ -1,6 +1,6 @@
 resource "azurerm_data_protection_backup_policy_postgresql_flexible_server" "backup_policy" {
-  name                            = "bkpol-${var.vault_name}-pgflexserver-${var.backup_name}"
-  vault_id                        = var.vault_id
+  name                            = "bkpol-pgflex-${var.backup_name}"
+  vault_id                        = var.vault.id
   backup_repeating_time_intervals = var.backup_intervals
 
   default_retention_rule {

--- a/infrastructure/modules/backup/postgresql_flexible_server/variables.tf
+++ b/infrastructure/modules/backup/postgresql_flexible_server/variables.tf
@@ -1,17 +1,5 @@
-variable "vault_id" {
-  type = string
-}
-
-variable "vault_name" {
-  type = string
-}
-
-variable "vault_location" {
-  type = string
-}
-
-variable "vault_principal_id" {
-  type = string
+variable "vault" {
+  type = any
 }
 
 variable "backup_name" {

--- a/infrastructure/resource_group.tf
+++ b/infrastructure/resource_group.tf
@@ -1,4 +1,4 @@
 resource "azurerm_resource_group" "resource_group" {
-  location = var.vault_location
-  name     = "rg-nhsbackup-${var.vault_name}"
+  location = var.resource_group_location
+  name     = var.resource_group_name
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,13 +1,17 @@
-variable "vault_name" {
+variable "resource_group_name" {
   type = string
 }
 
-variable "vault_location" {
+variable "resource_group_location" {
   type    = string
   default = "uksouth"
 }
 
-variable "vault_redundancy" {
+variable "backup_vault_name" {
+  type = string
+}
+
+variable "backup_vault_redundancy" {
   type    = string
   default = "LocallyRedundant"
 }

--- a/tests/end-to-end-tests/basic_deployment_test.go
+++ b/tests/end-to-end-tests/basic_deployment_test.go
@@ -20,11 +20,11 @@ func TestBasicDeployment(t *testing.T) {
 	environment := GetEnvironmentConfiguration(t)
 	credential := GetAzureCredential(t, environment)
 
-	vaultName := random.UniqueId()
-	vaultLocation := "uksouth"
-	vaultRedundancy := "LocallyRedundant"
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", vaultName)
-	backupVaultName := fmt.Sprintf("bvault-%s", vaultName)
+	uniqueId := random.UniqueId()
+	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", uniqueId)
+	resourceGroupLocation := "uksouth"
+	backupVaultName := fmt.Sprintf("bvault-nhsbackup-%s", uniqueId)
+	backupVaultRedundancy := "LocallyRedundant"
 
 	// Teardown stage
 	// ...
@@ -43,16 +43,17 @@ func TestBasicDeployment(t *testing.T) {
 			TerraformDir: environment.TerraformFolder,
 
 			Vars: map[string]interface{}{
-				"vault_name":       vaultName,
-				"vault_location":   vaultLocation,
-				"vault_redundancy": vaultRedundancy,
+				"resource_group_name":     resourceGroupName,
+				"resource_group_location": resourceGroupLocation,
+				"backup_vault_name":       backupVaultName,
+				"backup_vault_redundancy": backupVaultRedundancy,
 			},
 
 			BackendConfig: map[string]interface{}{
 				"resource_group_name":  environment.TerraformStateResourceGroup,
 				"storage_account_name": environment.TerraformStateStorageAccount,
 				"container_name":       environment.TerraformStateContainer,
-				"key":                  vaultName + ".tfstate",
+				"key":                  backupVaultName + ".tfstate",
 			},
 		}
 
@@ -69,13 +70,13 @@ func TestBasicDeployment(t *testing.T) {
 		resourceGroup := GetResourceGroup(t, environment.SubscriptionID, credential, resourceGroupName)
 		assert.NotNil(t, resourceGroup, "Resource group does not exist")
 		assert.Equal(t, resourceGroupName, *resourceGroup.Name, "Resource group name does not match")
-		assert.Equal(t, vaultLocation, *resourceGroup.Location, "Resource group location does not match")
+		assert.Equal(t, resourceGroupLocation, *resourceGroup.Location, "Resource group location does not match")
 
 		// Validate backup vault
 		backupVault := GetBackupVault(t, credential, environment.SubscriptionID, resourceGroupName, backupVaultName)
 		assert.NotNil(t, backupVault, "Backup vault does not exist")
 		assert.Equal(t, backupVaultName, *backupVault.Name, "Backup vault name does not match")
-		assert.Equal(t, vaultLocation, *backupVault.Location, "Backup vault location does not match")
+		assert.Equal(t, resourceGroupLocation, *backupVault.Location, "Backup vault location does not match")
 		assert.NotNil(t, backupVault.Identity.PrincipalID, "Backup vault identity does not exist")
 		assert.Equal(t, "SystemAssigned", *backupVault.Identity.Type, "Backup vault identity type does not match")
 		assert.Equal(t, armdataprotection.StorageSettingTypesLocallyRedundant, *backupVault.Properties.StorageSettings[0].Type, "Backup vault redundancy does not match")

--- a/tests/end-to-end-tests/blob_storage_backup_test.go
+++ b/tests/end-to-end-tests/blob_storage_backup_test.go
@@ -133,7 +133,7 @@ func TestBlobStorageBackup(t *testing.T) {
 			storageAccountId := backup["storage_account_id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-blobstorage-%s", backupVaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-blob-%s", backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -144,7 +144,7 @@ func TestBlobStorageBackup(t *testing.T) {
 			assert.Equal(t, retentionPeriod, *deleteOption.Duration, "Expected the backup policy retention period to be %s", retentionPeriod)
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-blobstorage-%s", backupVaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-blob-%s", backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, storageAccountId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", storageAccountId)

--- a/tests/end-to-end-tests/blob_storage_backup_test.go
+++ b/tests/end-to-end-tests/blob_storage_backup_test.go
@@ -25,15 +25,15 @@ type TestBlobStorageBackupExternalResources struct {
  * Creates resources which are "external" to the az-backup module, and models
  * what would be backed up in a real scenario.
  */
-func setupExternalResourcesForBlobStorageBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, vault_name string, vault_location string) *TestBlobStorageBackupExternalResources {
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s-external", vault_name)
-	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, resourceGroupName, vault_location)
+func setupExternalResourcesForBlobStorageBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, resourceGroupName string, resourceGroupLocation string, uniqueId string) *TestBlobStorageBackupExternalResources {
+	externalResourceGroupName := fmt.Sprintf("%s-external", resourceGroupName)
+	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
-	storageAccountOneName := fmt.Sprintf("sa%sexternal1", strings.ToLower(vault_name))
-	storageAccountOne := CreateStorageAccount(t, credential, subscriptionID, resourceGroupName, storageAccountOneName, vault_location)
+	storageAccountOneName := fmt.Sprintf("sa%sexternal1", strings.ToLower(uniqueId))
+	storageAccountOne := CreateStorageAccount(t, credential, subscriptionID, externalResourceGroupName, storageAccountOneName, resourceGroupLocation)
 
-	storageAccountTwoName := fmt.Sprintf("sa%sexternal2", strings.ToLower(vault_name))
-	storageAccountTwo := CreateStorageAccount(t, credential, subscriptionID, resourceGroupName, storageAccountTwoName, vault_location)
+	storageAccountTwoName := fmt.Sprintf("sa%sexternal2", strings.ToLower(uniqueId))
+	storageAccountTwo := CreateStorageAccount(t, credential, subscriptionID, externalResourceGroupName, storageAccountTwoName, resourceGroupLocation)
 
 	externalResources := &TestBlobStorageBackupExternalResources{
 		ResourceGroup:     resourceGroup,
@@ -53,13 +53,13 @@ func TestBlobStorageBackup(t *testing.T) {
 	environment := GetEnvironmentConfiguration(t)
 	credential := GetAzureCredential(t, environment)
 
-	vaultName := random.UniqueId()
-	vaultLocation := "uksouth"
-	vaultRedundancy := "LocallyRedundant"
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", vaultName)
-	backupVaultName := fmt.Sprintf("bvault-%s", vaultName)
+	uniqueId := random.UniqueId()
+	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", uniqueId)
+	resourceGroupLocation := "uksouth"
+	backupVaultName := fmt.Sprintf("bvault-nhsbackup-%s", uniqueId)
+	backupVaultRedundancy := "LocallyRedundant"
 
-	externalResources := setupExternalResourcesForBlobStorageBackupTest(t, credential, environment.SubscriptionID, vaultName, vaultLocation)
+	externalResources := setupExternalResourcesForBlobStorageBackupTest(t, credential, environment.SubscriptionID, resourceGroupName, resourceGroupLocation, uniqueId)
 
 	// A map of backups which we'll use to apply the TF module, and then validate the
 	// policies have been created correctly
@@ -95,17 +95,18 @@ func TestBlobStorageBackup(t *testing.T) {
 			TerraformDir: environment.TerraformFolder,
 
 			Vars: map[string]interface{}{
-				"vault_name":           vaultName,
-				"vault_location":       vaultLocation,
-				"vault_redundancy":     vaultRedundancy,
-				"blob_storage_backups": blobStorageBackups,
+				"resource_group_name":     resourceGroupName,
+				"resource_group_location": resourceGroupLocation,
+				"backup_vault_name":       backupVaultName,
+				"backup_vault_redundancy": backupVaultRedundancy,
+				"blob_storage_backups":    blobStorageBackups,
 			},
 
 			BackendConfig: map[string]interface{}{
 				"resource_group_name":  environment.TerraformStateResourceGroup,
 				"storage_account_name": environment.TerraformStateStorageAccount,
 				"container_name":       environment.TerraformStateContainer,
-				"key":                  vaultName + ".tfstate",
+				"key":                  backupVaultName + ".tfstate",
 			},
 		}
 
@@ -132,7 +133,7 @@ func TestBlobStorageBackup(t *testing.T) {
 			storageAccountId := backup["storage_account_id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-blobstorage-%s", vaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-%s-blobstorage-%s", backupVaultName, backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -143,7 +144,7 @@ func TestBlobStorageBackup(t *testing.T) {
 			assert.Equal(t, retentionPeriod, *deleteOption.Duration, "Expected the backup policy retention period to be %s", retentionPeriod)
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-blobstorage-%s", vaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-%s-blobstorage-%s", backupVaultName, backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, storageAccountId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", storageAccountId)

--- a/tests/end-to-end-tests/diagnostic_settings_test.go
+++ b/tests/end-to-end-tests/diagnostic_settings_test.go
@@ -28,7 +28,7 @@ func setupExternalResourcesForDiagnosticSettingsTest(t *testing.T, credential *a
 	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
 	logAnalyticsWorkspaceName := fmt.Sprintf("law-%s-external", strings.ToLower(uniqueId))
-	logAnalyticsWorkspace := CreateLogAnalyticsWorkspace(t, credential, subscriptionID, resourceGroupName, logAnalyticsWorkspaceName, resourceGroupLocation)
+	logAnalyticsWorkspace := CreateLogAnalyticsWorkspace(t, credential, subscriptionID, externalResourceGroupName, logAnalyticsWorkspaceName, resourceGroupLocation)
 
 	externalResources := &TestDiagnosticSettingsExternalResources{
 		ResourceGroup:         resourceGroup,

--- a/tests/end-to-end-tests/managed_disk_backup_test.go
+++ b/tests/end-to-end-tests/managed_disk_backup_test.go
@@ -30,10 +30,10 @@ func setupExternalResourcesForManagedDiskBackupTest(t *testing.T, credential *az
 	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
 	managedDiskOneName := fmt.Sprintf("disk-%s-external-1", strings.ToLower(uniqueId))
-	managedDiskOne := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskOneName, resourceGroupLocation, int32(1))
+	managedDiskOne := CreateManagedDisk(t, credential, subscriptionID, externalResourceGroupName, managedDiskOneName, resourceGroupLocation, int32(1))
 
 	managedDiskTwoName := fmt.Sprintf("disk-%s-external-2", strings.ToLower(uniqueId))
-	managedDiskTwo := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskTwoName, resourceGroupLocation, int32(1))
+	managedDiskTwo := CreateManagedDisk(t, credential, subscriptionID, externalResourceGroupName, managedDiskTwoName, resourceGroupLocation, int32(1))
 
 	externalResources := &TestManagedDiskBackupExternalResources{
 		ResourceGroup:  resourceGroup,
@@ -146,7 +146,7 @@ func TestManagedDiskBackup(t *testing.T) {
 			managedDiskResourceGroupId := managedDiskResourceGroup["id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-manageddisk-%s", backupVaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-disk-%s", backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -164,7 +164,7 @@ func TestManagedDiskBackup(t *testing.T) {
 			}
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-manageddisk-%s", backupVaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-disk-%s", backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, managedDiskId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", managedDiskId)

--- a/tests/end-to-end-tests/managed_disk_backup_test.go
+++ b/tests/end-to-end-tests/managed_disk_backup_test.go
@@ -25,15 +25,15 @@ type TestManagedDiskBackupExternalResources struct {
  * Creates resources which are "external" to the az-backup module, and models
  * what would be backed up in a real scenario.
  */
-func setupExternalResourcesForManagedDiskBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, vault_name string, vault_location string) *TestManagedDiskBackupExternalResources {
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s-external", vault_name)
-	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, resourceGroupName, vault_location)
+func setupExternalResourcesForManagedDiskBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, resourceGroupName string, resourceGroupLocation string, uniqueId string) *TestManagedDiskBackupExternalResources {
+	externalResourceGroupName := fmt.Sprintf("%s-external", resourceGroupName)
+	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
-	managedDiskOneName := fmt.Sprintf("disk-%s-external-1", strings.ToLower(vault_name))
-	managedDiskOne := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskOneName, vault_location, int32(1))
+	managedDiskOneName := fmt.Sprintf("disk-%s-external-1", strings.ToLower(uniqueId))
+	managedDiskOne := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskOneName, resourceGroupLocation, int32(1))
 
-	managedDiskTwoName := fmt.Sprintf("disk-%s-external-2", strings.ToLower(vault_name))
-	managedDiskTwo := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskTwoName, vault_location, int32(1))
+	managedDiskTwoName := fmt.Sprintf("disk-%s-external-2", strings.ToLower(uniqueId))
+	managedDiskTwo := CreateManagedDisk(t, credential, subscriptionID, resourceGroupName, managedDiskTwoName, resourceGroupLocation, int32(1))
 
 	externalResources := &TestManagedDiskBackupExternalResources{
 		ResourceGroup:  resourceGroup,
@@ -53,13 +53,13 @@ func TestManagedDiskBackup(t *testing.T) {
 	environment := GetEnvironmentConfiguration(t)
 	credential := GetAzureCredential(t, environment)
 
-	vaultName := random.UniqueId()
-	vaultLocation := "uksouth"
-	vaultRedundancy := "LocallyRedundant"
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", vaultName)
-	backupVaultName := fmt.Sprintf("bvault-%s", vaultName)
+	uniqueId := random.UniqueId()
+	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", uniqueId)
+	resourceGroupLocation := "uksouth"
+	backupVaultName := fmt.Sprintf("bvault-nhsbackup-%s", uniqueId)
+	backupVaultRedundancy := "LocallyRedundant"
 
-	externalResources := setupExternalResourcesForManagedDiskBackupTest(t, credential, environment.SubscriptionID, vaultName, vaultLocation)
+	externalResources := setupExternalResourcesForManagedDiskBackupTest(t, credential, environment.SubscriptionID, resourceGroupName, resourceGroupLocation, uniqueId)
 
 	// A map of backups which we'll use to apply the TF module, and then validate the
 	// policies have been created correctly
@@ -105,17 +105,18 @@ func TestManagedDiskBackup(t *testing.T) {
 			TerraformDir: environment.TerraformFolder,
 
 			Vars: map[string]interface{}{
-				"vault_name":           vaultName,
-				"vault_location":       vaultLocation,
-				"vault_redundancy":     vaultRedundancy,
-				"managed_disk_backups": managedDiskBackups,
+				"resource_group_name":     resourceGroupName,
+				"resource_group_location": resourceGroupLocation,
+				"backup_vault_name":       backupVaultName,
+				"backup_vault_redundancy": backupVaultRedundancy,
+				"managed_disk_backups":    managedDiskBackups,
 			},
 
 			BackendConfig: map[string]interface{}{
 				"resource_group_name":  environment.TerraformStateResourceGroup,
 				"storage_account_name": environment.TerraformStateStorageAccount,
 				"container_name":       environment.TerraformStateContainer,
-				"key":                  vaultName + ".tfstate",
+				"key":                  backupVaultName + ".tfstate",
 			},
 		}
 
@@ -145,7 +146,7 @@ func TestManagedDiskBackup(t *testing.T) {
 			managedDiskResourceGroupId := managedDiskResourceGroup["id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-manageddisk-%s", vaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-%s-manageddisk-%s", backupVaultName, backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -163,7 +164,7 @@ func TestManagedDiskBackup(t *testing.T) {
 			}
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-manageddisk-%s", vaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-%s-manageddisk-%s", backupVaultName, backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, managedDiskId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", managedDiskId)

--- a/tests/end-to-end-tests/postgresql_flexible_server_backup_test.go
+++ b/tests/end-to-end-tests/postgresql_flexible_server_backup_test.go
@@ -25,15 +25,15 @@ type TestPostgresqlFlexibleServerBackupExternalResources struct {
  * Creates resources which are "external" to the az-backup module, and models
  * what would be backed up in a real scenario.
  */
-func setupExternalResourcesForPostgresqlFlexibleServerBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, vault_name string, vault_location string) *TestPostgresqlFlexibleServerBackupExternalResources {
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s-external", vault_name)
-	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, resourceGroupName, vault_location)
+func setupExternalResourcesForPostgresqlFlexibleServerBackupTest(t *testing.T, credential *azidentity.ClientSecretCredential, subscriptionID string, resourceGroupName string, resourceGroupLocation string, uniqueId string) *TestPostgresqlFlexibleServerBackupExternalResources {
+	externalResourceGroupName := fmt.Sprintf("%s-external", resourceGroupName)
+	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
-	PostgresqlFlexibleServerOneName := fmt.Sprintf("pgflexserver-%s-external-1", strings.ToLower(vault_name))
-	PostgresqlFlexibleServerOne := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerOneName, vault_location, int32(32))
+	PostgresqlFlexibleServerOneName := fmt.Sprintf("pgflexserver-%s-external-1", strings.ToLower(uniqueId))
+	PostgresqlFlexibleServerOne := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerOneName, resourceGroupLocation, int32(32))
 
-	PostgresqlFlexibleServerTwoName := fmt.Sprintf("pgflexserver-%s-external-2", strings.ToLower(vault_name))
-	PostgresqlFlexibleServerTwo := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerTwoName, vault_location, int32(32))
+	PostgresqlFlexibleServerTwoName := fmt.Sprintf("pgflexserver-%s-external-2", strings.ToLower(uniqueId))
+	PostgresqlFlexibleServerTwo := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerTwoName, resourceGroupLocation, int32(32))
 
 	externalResources := &TestPostgresqlFlexibleServerBackupExternalResources{
 		ResourceGroup:               resourceGroup,
@@ -53,13 +53,13 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 	environment := GetEnvironmentConfiguration(t)
 	credential := GetAzureCredential(t, environment)
 
-	vaultName := random.UniqueId()
-	vaultLocation := "uksouth"
-	vaultRedundancy := "LocallyRedundant"
-	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", vaultName)
-	backupVaultName := fmt.Sprintf("bvault-%s", vaultName)
+	uniqueId := random.UniqueId()
+	resourceGroupName := fmt.Sprintf("rg-nhsbackup-%s", uniqueId)
+	resourceGroupLocation := "uksouth"
+	backupVaultName := fmt.Sprintf("bvault-nhsbackup-%s", uniqueId)
+	backupVaultRedundancy := "LocallyRedundant"
 
-	externalResources := setupExternalResourcesForPostgresqlFlexibleServerBackupTest(t, credential, environment.SubscriptionID, vaultName, vaultLocation)
+	externalResources := setupExternalResourcesForPostgresqlFlexibleServerBackupTest(t, credential, environment.SubscriptionID, resourceGroupName, resourceGroupLocation, uniqueId)
 
 	// A map of backups which we'll use to apply the TF module, and then validate the
 	// policies have been created correctly
@@ -99,9 +99,10 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 			TerraformDir: environment.TerraformFolder,
 
 			Vars: map[string]interface{}{
-				"vault_name":                         vaultName,
-				"vault_location":                     vaultLocation,
-				"vault_redundancy":                   vaultRedundancy,
+				"resource_group_name":                resourceGroupName,
+				"resource_group_location":            resourceGroupLocation,
+				"backup_vault_name":                  backupVaultName,
+				"backup_vault_redundancy":            backupVaultRedundancy,
 				"postgresql_flexible_server_backups": PostgresqlFlexibleServerBackups,
 			},
 
@@ -109,7 +110,7 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 				"resource_group_name":  environment.TerraformStateResourceGroup,
 				"storage_account_name": environment.TerraformStateStorageAccount,
 				"container_name":       environment.TerraformStateContainer,
-				"key":                  vaultName + ".tfstate",
+				"key":                  backupVaultName + ".tfstate",
 			},
 		}
 
@@ -138,7 +139,7 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 			ServerResourceGroupId := backup["server_resource_group_id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-pgflexserver-%s", vaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-%s-pgflexserver-%s", backupVaultName, backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -156,7 +157,7 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 			}
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-pgflexserver-%s", vaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-%s-pgflexserver-%s", backupVaultName, backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, ServerId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", ServerId)

--- a/tests/end-to-end-tests/postgresql_flexible_server_backup_test.go
+++ b/tests/end-to-end-tests/postgresql_flexible_server_backup_test.go
@@ -30,10 +30,10 @@ func setupExternalResourcesForPostgresqlFlexibleServerBackupTest(t *testing.T, c
 	resourceGroup := CreateResourceGroup(t, credential, subscriptionID, externalResourceGroupName, resourceGroupLocation)
 
 	PostgresqlFlexibleServerOneName := fmt.Sprintf("pgflexserver-%s-external-1", strings.ToLower(uniqueId))
-	PostgresqlFlexibleServerOne := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerOneName, resourceGroupLocation, int32(32))
+	PostgresqlFlexibleServerOne := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, externalResourceGroupName, PostgresqlFlexibleServerOneName, resourceGroupLocation, int32(32))
 
 	PostgresqlFlexibleServerTwoName := fmt.Sprintf("pgflexserver-%s-external-2", strings.ToLower(uniqueId))
-	PostgresqlFlexibleServerTwo := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, resourceGroupName, PostgresqlFlexibleServerTwoName, resourceGroupLocation, int32(32))
+	PostgresqlFlexibleServerTwo := CreatePostgresqlFlexibleServer(t, credential, subscriptionID, externalResourceGroupName, PostgresqlFlexibleServerTwoName, resourceGroupLocation, int32(32))
 
 	externalResources := &TestPostgresqlFlexibleServerBackupExternalResources{
 		ResourceGroup:               resourceGroup,
@@ -139,7 +139,7 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 			ServerResourceGroupId := backup["server_resource_group_id"].(string)
 
 			// Validate backup policy
-			backupPolicyName := fmt.Sprintf("bkpol-%s-pgflexserver-%s", backupVaultName, backupName)
+			backupPolicyName := fmt.Sprintf("bkpol-pgflex-%s", backupName)
 			backupPolicy := GetBackupPolicyForName(backupPolicies, backupPolicyName)
 			assert.NotNil(t, backupPolicy, "Expected to find a backup policy called %s", backupPolicyName)
 
@@ -157,7 +157,7 @@ func TestPostgresqlFlexibleServerBackup(t *testing.T) {
 			}
 
 			// Validate backup instance
-			backupInstanceName := fmt.Sprintf("bkinst-%s-pgflexserver-%s", backupVaultName, backupName)
+			backupInstanceName := fmt.Sprintf("bkinst-pgflex-%s", backupName)
 			backupInstance := GetBackupInstanceForName(backupInstances, backupInstanceName)
 			assert.NotNil(t, backupInstance, "Expected to find a backup policy called %s", backupInstanceName)
 			assert.Equal(t, ServerId, *backupInstance.Properties.DataSourceInfo.ResourceID, "Expected the backup instance source resource ID to be %s", ServerId)

--- a/tests/integration-tests/backup_modules_blob_storage.tftest.hcl
+++ b/tests/integration-tests/backup_modules_blob_storage.tftest.hcl
@@ -16,8 +16,9 @@ run "create_blob_storage_backup" {
   }
 
   variables {
-    vault_name     = run.setup_tests.vault_name
-    vault_location = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location = "uksouth"
+    backup_vault_name     = run.setup_tests.backup_vault_name
     blob_storage_backups = {
       backup1 = {
         backup_name        = "storage1"

--- a/tests/integration-tests/backup_modules_blob_storage.tftest.hcl
+++ b/tests/integration-tests/backup_modules_blob_storage.tftest.hcl
@@ -43,7 +43,7 @@ run "create_blob_storage_backup" {
   }
 
   assert {
-    condition     = module.blob_storage_backup["backup1"].backup_policy.name == "bkpol-${var.vault_name}-blobstorage-storage1"
+    condition     = module.blob_storage_backup["backup1"].backup_policy.name == "bkpol-blob-storage1"
     error_message = "Blob storage backup policy name not as expected."
   }
 
@@ -63,7 +63,7 @@ run "create_blob_storage_backup" {
   }
 
   assert {
-    condition     = module.blob_storage_backup["backup1"].backup_instance.name == "bkinst-${var.vault_name}-blobstorage-storage1"
+    condition     = module.blob_storage_backup["backup1"].backup_instance.name == "bkinst-blob-storage1"
     error_message = "Blob storage backup instance name not as expected."
   }
 
@@ -93,7 +93,7 @@ run "create_blob_storage_backup" {
   }
 
   assert {
-    condition     = module.blob_storage_backup["backup2"].backup_policy.name == "bkpol-${var.vault_name}-blobstorage-storage2"
+    condition     = module.blob_storage_backup["backup2"].backup_policy.name == "bkpol-blob-storage2"
     error_message = "Blob storage backup policy name not as expected."
   }
 
@@ -113,7 +113,7 @@ run "create_blob_storage_backup" {
   }
 
   assert {
-    condition     = module.blob_storage_backup["backup2"].backup_instance.name == "bkinst-${var.vault_name}-blobstorage-storage2"
+    condition     = module.blob_storage_backup["backup2"].backup_instance.name == "bkinst-blob-storage2"
     error_message = "Blob storage backup instance name not as expected."
   }
 

--- a/tests/integration-tests/backup_modules_managed_disk.tftest.hcl
+++ b/tests/integration-tests/backup_modules_managed_disk.tftest.hcl
@@ -16,8 +16,9 @@ run "create_managed_disk_backup" {
   }
 
   variables {
-    vault_name     = run.setup_tests.vault_name
-    vault_location = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location = "uksouth"
+    backup_vault_name     = run.setup_tests.backup_vault_name
     managed_disk_backups = {
       backup1 = {
         backup_name      = "disk1"

--- a/tests/integration-tests/backup_modules_managed_disk.tftest.hcl
+++ b/tests/integration-tests/backup_modules_managed_disk.tftest.hcl
@@ -53,7 +53,7 @@ run "create_managed_disk_backup" {
   }
 
   assert {
-    condition     = module.managed_disk_backup["backup1"].backup_policy.name == "bkpol-${var.vault_name}-manageddisk-disk1"
+    condition     = module.managed_disk_backup["backup1"].backup_policy.name == "bkpol-disk-disk1"
     error_message = "Managed disk backup policy name not as expected."
   }
 
@@ -78,7 +78,7 @@ run "create_managed_disk_backup" {
   }
 
   assert {
-    condition     = module.managed_disk_backup["backup1"].backup_instance.name == "bkinst-${var.vault_name}-manageddisk-disk1"
+    condition     = module.managed_disk_backup["backup1"].backup_instance.name == "bkinst-disk-disk1"
     error_message = "Managed disk backup instance name not as expected."
   }
 
@@ -113,7 +113,7 @@ run "create_managed_disk_backup" {
   }
 
   assert {
-    condition     = module.managed_disk_backup["backup2"].backup_policy.name == "bkpol-${var.vault_name}-manageddisk-disk2"
+    condition     = module.managed_disk_backup["backup2"].backup_policy.name == "bkpol-disk-disk2"
     error_message = "Managed disk backup policy name not as expected."
   }
 
@@ -138,7 +138,7 @@ run "create_managed_disk_backup" {
   }
 
   assert {
-    condition     = module.managed_disk_backup["backup2"].backup_instance.name == "bkinst-${var.vault_name}-manageddisk-disk2"
+    condition     = module.managed_disk_backup["backup2"].backup_instance.name == "bkinst-disk-disk2"
     error_message = "Managed disk backup instance name not as expected."
   }
 

--- a/tests/integration-tests/backup_modules_postgresql_flexible_server.tftest.hcl
+++ b/tests/integration-tests/backup_modules_postgresql_flexible_server.tftest.hcl
@@ -16,8 +16,9 @@ run "create_postgresql_flexible_server_backup" {
   }
 
   variables {
-    vault_name     = run.setup_tests.vault_name
-    vault_location = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location = "uksouth"
+    backup_vault_name     = run.setup_tests.backup_vault_name
     postgresql_flexible_server_backups = {
       backup1 = {
         backup_name      = "server1"

--- a/tests/integration-tests/backup_modules_postgresql_flexible_server.tftest.hcl
+++ b/tests/integration-tests/backup_modules_postgresql_flexible_server.tftest.hcl
@@ -47,7 +47,7 @@ run "create_postgresql_flexible_server_backup" {
   }
 
   assert {
-    condition     = module.postgresql_flexible_server_backup["backup1"].backup_policy.name == "bkpol-${var.vault_name}-pgflexserver-server1"
+    condition     = module.postgresql_flexible_server_backup["backup1"].backup_policy.name == "bkpol-pgflex-server1"
     error_message = "Postgresql flexible server backup policy name not as expected."
   }
 
@@ -72,7 +72,7 @@ run "create_postgresql_flexible_server_backup" {
   }
 
   assert {
-    condition     = module.postgresql_flexible_server_backup["backup1"].backup_instance.name == "bkinst-${var.vault_name}-pgflexserver-server1"
+    condition     = module.postgresql_flexible_server_backup["backup1"].backup_instance.name == "bkinst-pgflex-server1"
     error_message = "Postgresql flexible server backup instance name not as expected."
   }
 
@@ -102,7 +102,7 @@ run "create_postgresql_flexible_server_backup" {
   }
 
   assert {
-    condition     = module.postgresql_flexible_server_backup["backup2"].backup_policy.name == "bkpol-${var.vault_name}-pgflexserver-server2"
+    condition     = module.postgresql_flexible_server_backup["backup2"].backup_policy.name == "bkpol-pgflex-server2"
     error_message = "Postgresql flexible server backup policy name not as expected."
   }
 
@@ -127,7 +127,7 @@ run "create_postgresql_flexible_server_backup" {
   }
 
   assert {
-    condition     = module.postgresql_flexible_server_backup["backup2"].backup_instance.name == "bkinst-${var.vault_name}-pgflexserver-server2"
+    condition     = module.postgresql_flexible_server_backup["backup2"].backup_instance.name == "bkinst-pgflex-server2"
     error_message = "Postgresql flexible server backup instance name not as expected."
   }
 

--- a/tests/integration-tests/backup_vault.tftest.hcl
+++ b/tests/integration-tests/backup_vault.tftest.hcl
@@ -16,13 +16,14 @@ run "create_backup_vault" {
   }
 
   variables {
-    vault_name       = run.setup_tests.vault_name
-    vault_location   = "uksouth"
-    vault_redundancy = "LocallyRedundant"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location   = "uksouth"
+    backup_vault_name       = run.setup_tests.backup_vault_name
+    backup_vault_redundancy = "LocallyRedundant"
   }
 
   assert {
-    condition     = azurerm_data_protection_backup_vault.backup_vault.name == "bvault-${var.vault_name}"
+    condition     = azurerm_data_protection_backup_vault.backup_vault.name == var.backup_vault_name
     error_message = "Backup vault name not as expected."
   }
 
@@ -32,7 +33,7 @@ run "create_backup_vault" {
   }
 
   assert {
-    condition     = azurerm_data_protection_backup_vault.backup_vault.location == var.vault_location
+    condition     = azurerm_data_protection_backup_vault.backup_vault.location == azurerm_resource_group.resource_group.location
     error_message = "Backup vault location not as expected."
   }
 
@@ -42,7 +43,7 @@ run "create_backup_vault" {
   }
 
   assert {
-    condition     = azurerm_data_protection_backup_vault.backup_vault.redundancy == var.vault_redundancy
+    condition     = azurerm_data_protection_backup_vault.backup_vault.redundancy == var.backup_vault_redundancy
     error_message = "Backup vault redundancy not as expected."
   }
 
@@ -65,8 +66,9 @@ run "configure_vault_diagnostics_when_enabled" {
   }
 
   variables {
-    vault_name                 = run.setup_tests.vault_name
-    vault_location             = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location             = "uksouth"
+    backup_vault_name                 = run.setup_tests.backup_vault_name
     log_analytics_workspace_id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.OperationalInsights/workspaces/workspace1"
   }
 
@@ -114,8 +116,9 @@ run "configure_vault_diagnostics_when_disabled" {
   }
 
   variables {
-    vault_name     = run.setup_tests.vault_name
-    vault_location = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location             = "uksouth"
+    backup_vault_name                 = run.setup_tests.backup_vault_name
   }
 
   assert {

--- a/tests/integration-tests/resource_group.tftest.hcl
+++ b/tests/integration-tests/resource_group.tftest.hcl
@@ -16,17 +16,18 @@ run "create_resource_group" {
   }
 
   variables {
-    vault_name     = run.setup_tests.vault_name
-    vault_location = "uksouth"
+    resource_group_name     = run.setup_tests.resource_group_name
+    resource_group_location = "uksouth"
+    backup_vault_name     = run.setup_tests.backup_vault_name
   }
 
   assert {
-    condition     = azurerm_resource_group.resource_group.name == "rg-nhsbackup-${var.vault_name}"
+    condition     = azurerm_resource_group.resource_group.name == var.resource_group_name
     error_message = "Resource group name not as expected."
   }
 
   assert {
-    condition     = azurerm_resource_group.resource_group.location == var.vault_location
+    condition     = azurerm_resource_group.resource_group.location == var.resource_group_location
     error_message = "Resource group location not as expected."
   }
 }

--- a/tests/integration-tests/setup/main.tf
+++ b/tests/integration-tests/setup/main.tf
@@ -7,10 +7,14 @@ terraform {
   }
 }
 
-resource "random_pet" "vault_name" {
+resource "random_pet" "backup_vault_name" {
   length = 4
 }
 
-output "vault_name" {
-  value = random_pet.vault_name.id
+output "resource_group_name" {
+  value = "rg-${random_pet.backup_vault_name.id}"
+}
+
+output "backup_vault_name" {
+  value = "bvault-${random_pet.backup_vault_name.id}"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 --> 
<!-- To cross through text ~~surround it in double tildes like this~~ --> 

## Description

An update to how resources created by the module are named. Consumers will be able to configure the name of the resource group and backup vault independently.

## Type of change

Please check the relevant options, or cross through options which are not applicable to this change:

✅ New feature (a change which adds functionality)
🔲 Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
✅ Testing (new tests, or improvements to existing tests)
✅ Pipelines (changes to pipelines and workflows)
✅ Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options, or cross through options which are not applicable to this change:

✅ My code aligns with the style of this project
✅ I have added comments in hard to understand areas
✅ I have added tests that prove my change works
✅ I have updated the documentation

## Additional Information

n/a
