### PR TITLE
Update backup_vault.tf

### DIFF
--- a/infrastructure/backup_vault.tf
+++ b/infrastructure/backup_vault.tf
@@ -5,25 +5,13 @@ resource "azurerm_data_protection_backup_vault" "backup_vault" {
   datastore_type      = "VaultStore"
   redundancy          = var.backup_vault_redundancy
   soft_delete         = "Off"
+  immutability        = var.backup_vault_immutability
   tags                = var.tags
   identity {
     type = "SystemAssigned"
   }
 }
 
-resource "azapi_update_resource" "backup_vault_settings" {
-  type        = "Microsoft.DataProtection/backupVaults@2022-11-01-preview"
-  resource_id = azurerm_data_protection_backup_vault.backup_vault.id
-  body = jsonencode({
-    properties = {
-      securitySettings = {
-        immutabilitySettings = {
-          state = var.backup_vault_immutability
-        }
-      }
-    }
-  })
-}
 
 locals {
   backup_vault_diagnostics_log_categories = toset([


### PR DESCRIPTION
removed API update block and added Immutability to AzureRM block

<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

Please provide a brief summary of the changes made in this pull request.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
✅ Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:
✅ My code aligns with the style of this project
🔲 I have added comments in hard to understand areas
🔲 I have added tests that prove my change works
🔲 I have updated the documentation
🔲 If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

Please provide any additional information or context related to this pull request.
Currently backup module use API update to set immutability settings - which isn't refreshing the state of backup vault - keeps on changing back value to disable or unlocked  - Since last month Azure RM released functionality to in-corporate immutability settings - hence we replaced API update with native AzureRM functionality.