### PR TITLE
Extended the azurerm provider version to be a range rather than a specific version

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.18.0"
+      version = ">= 4.18.0, < 5.0"
     }
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

Use a range version constraint syntax for specifying the azurerm provider rather than specifying a specific version. This enables root projects to have more flexibility on the version of the provider, and will not drive unnecessary version upgrades. 

## Type of change

🔲 New feature (a change which adds functionality)
🔲 Bug fix (a change which fixes an issue)
✅ Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

✅ My code aligns with the style of this project
🔲 I have added comments in hard to understand areas
🔲 I have added tests that prove my change works
🔲 I have updated the documentation
🔲 If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

Supports version greater than or equal to 4.18.0 but less than 5.0.0
