### PR TITLE
Remove azurerm provider declaration

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -10,9 +10,3 @@ terraform {
 
   backend "azurerm" {}
 }
-
-provider "azurerm" {
-  features {}
-}
-
-

--- a/tests/end-to-end-tests/go.mod
+++ b/tests/end-to-end-tests/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
+	github.com/gruntwork-io/go-commons v0.17.2
 	github.com/gruntwork-io/terratest v0.48.2
 	github.com/stretchr/testify v1.10.0
 )
@@ -82,7 +83,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/gruntwork-io/go-commons v0.17.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter/v2 v2.2.3 // indirect

--- a/tests/end-to-end-tests/helpers.go
+++ b/tests/end-to-end-tests/helpers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/gruntwork-io/go-commons/files"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
@@ -41,6 +42,8 @@ type Config struct {
  */
 func GetEnvironmentConfiguration(t *testing.T) *Config {
 	terraformFolder := test_structure.CopyTerraformFolderToTemp(t, "../../infrastructure", "")
+
+	files.CopyFile("./provider.tf", terraformFolder+"/provider.tf")
 
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	if tenantID == "" {

--- a/tests/end-to-end-tests/provider.tf
+++ b/tests/end-to-end-tests/provider.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

Removed the azurerm provider declaration - this is not required in TF modules which will be consumed solely by other modules.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
🔲 Bug fix (a change which fixes an issue)
✅ Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:

✅ My code aligns with the style of this project
🔲 I have added comments in hard to understand areas
🔲 I have added tests that prove my change works
🔲 I have updated the documentation
✅ If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

The issue blocks consumers of the module from using features such as count and for_each.

The e2e tests require a provider as the module is tested as a root module, so an update has been made to the e2e tests to copy a provider file into the directory of the terraform being applied.