### PR TITLE
Adding ServiceType parameter to role assignments

### DIFF
--- a/infrastructure/modules/backup/blob_storage/backup_instance.tf
+++ b/infrastructure/modules/backup/blob_storage/backup_instance.tf
@@ -2,6 +2,7 @@ resource "azurerm_role_assignment" "role_assignment" {
   scope                = var.storage_account_id
   role_definition_name = "Storage Account Backup Contributor"
   principal_id         = var.vault.identity[0].principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_data_protection_backup_instance_blob_storage" "backup_instance" {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

The Azure Landing Zone User Access Admin role has specific ABAC conditions - one of those conditions is that any role requests must have the origin source as 'ServicePrincipal'.

Terraform does not set this tag - and this is fine for scenarios without ABAC. Due to the condition requiring the parameter, it must be set.

I have added a simple line to reflect this - it poses no dangers or downsides.

If this change was not made, we would not be able to consume this module within the Landing Zone.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
✅ Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:

✅ My code aligns with the style of this project
🔲 I have added comments in hard to understand areas **NA**
🔲 I have added tests that prove my change works **NA**
🔲 I have updated the documentation **NA**
✅ If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

Please provide any additional information or context related to this pull request.
