### PR TITLE
Add service principal type to meet conditions on User Access Administrator role

### DIFF
--- a/infrastructure/modules/backup/managed_disk/backup_instance.tf
+++ b/infrastructure/modules/backup/managed_disk/backup_instance.tf
@@ -3,12 +3,14 @@ resource "azurerm_role_assignment" "role_assignment_snapshot_contributor" {
   scope                = var.managed_disk_resource_group.id
   role_definition_name = "Disk Snapshot Contributor"
   principal_id         = var.vault.identity[0].principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_role_assignment" "role_assignment_backup_reader" {
   scope                = var.managed_disk_id
   role_definition_name = "Disk Backup Reader"
   principal_id         = var.vault.identity[0].principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_data_protection_backup_instance_disk" "backup_instance" {

--- a/infrastructure/modules/backup/postgresql_flexible_server/backup_instance.tf
+++ b/infrastructure/modules/backup/postgresql_flexible_server/backup_instance.tf
@@ -3,12 +3,14 @@ resource "azurerm_role_assignment" "role_assignment_reader" {
   scope                = var.server_resource_group_id
   role_definition_name = "Reader"
   principal_id         = var.vault.identity[0].principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_role_assignment" "role_assignment_long_term_retention_backup_role" {
   scope                = var.server_id
   role_definition_name = "PostgreSQL Flexible Server Long Term Retention Backup Role"
   principal_id         = var.vault.identity[0].principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_data_protection_backup_instance_postgresql_flexible_server" "backup_instance" {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

Add service principal type to meet conditions on User Access Administrator role. This allows deployment service principals, where the User Access Administrator has a condition on Service Principals only, to use this module.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
✅ Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:

✅ My code aligns with the style of this project
✅ I have added comments in hard to understand areas
🔲 I have added tests that prove my change works
🔲 I have updated the documentation
🔲 If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

Please provide any additional information or context related to this pull request.
