### PR TITLE
fix: Fix `use_extended_retention` condition

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -78,8 +78,8 @@ variable "blob_storage_backups" {
   }
 
   validation {
-    condition     = var.use_extended_retention == true || alltrue([for k, v in var.blob_storage_backups : contains(local.valid_retention_periods, v.retention_period)])
-    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_exetended_retention to true."
+    condition     = var.use_extended_retention ? true : alltrue([for k, v in var.blob_storage_backups : contains(local.valid_retention_periods, v.retention_period)])
+    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_extended_retention to true."
   }
 }
 
@@ -104,8 +104,8 @@ variable "managed_disk_backups" {
   }
 
   validation {
-    condition     = var.use_extended_retention == true || alltrue([for k, v in var.managed_disk_backups : contains(local.valid_retention_periods, v.retention_period)])
-    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_exetended_retention to true."
+    condition     = var.use_extended_retention ? true : alltrue([for k, v in var.managed_disk_backups : contains(local.valid_retention_periods, v.retention_period)])
+    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_extended_retention to true."
   }
 }
 
@@ -127,7 +127,7 @@ variable "postgresql_flexible_server_backups" {
   }
 
   validation {
-    condition     = var.use_extended_retention == true || alltrue([for k, v in var.postgresql_flexible_server_backups : contains(local.valid_retention_periods, v.retention_period)])
-    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_exetended_retention to true."
+    condition     = var.use_extended_retention ? true : alltrue([for k, v in var.postgresql_flexible_server_backups : contains(local.valid_retention_periods, v.retention_period)])
+    error_message = "Invalid retention period: valid periods are up to 7 days. If you require a longer retention period then please set use_extended_retention to true."
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

The validation on retention periods utilising `use_extended_retention` do not function as expected.

Even if you specify `use_extended_retention = true`, the condition will still fail:

```
│ Error: Invalid value for variable
│ 
│   on main.tf line 137, in module "az_backup":
│  137:   blob_storage_backups = {
│  138:     imagebackups = {
│  139:       backup_name                  = "imagebackups"
│  140:       retention_period             = "P30D"
│  141:       backup_intervals             = ["R/2025-01-01T00:00:00+00:00/P1D"]
│  142:       operational_retention_period = "P7D"
│  143:       use_extended_retention       = true
│  144:       storage_account_id           = azurerm_storage_account.backup_target.id
│  145:       storage_account_containers   = [
│  146:         azurerm_storage_container.nhsapp_images_sc.name
│  147:       ]
│  148:     }
│  149:   }
│     ├────────────────
│     │ local.valid_retention_periods is tuple with 7 elements
│     │ var.blob_storage_backups is map of object with 1 element
│     │ var.use_extended_retention is false
│ 
│ Invalid retention period: valid periods are up to 7 days. If you require a
│ longer retention period then please set use_exetended_retention to true.
│ 
│ This was checked by the validation rule at
│ .terraform/modules/az_backup/infrastructure/variables.tf:79,3-13.

```

This PR fixes that by only evaluating the condition if `use_extended_retention = false`.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
✅ Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
🔲 Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:

✅ My code aligns with the style of this project
🔲 I have added comments in hard to understand areas
🔲 I have added tests that prove my change works
🔲 I have updated the documentation
🔲 If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

N/A
