### PR TITLE
fix: Clean up end to end test resources

### DIFF
--- a/tests/end-to-end-tests/basic_deployment_test.go
+++ b/tests/end-to-end-tests/basic_deployment_test.go
@@ -69,6 +69,8 @@ func TestBasicDeployment(t *testing.T) {
 		terraformOptions := test_structure.LoadTerraformOptions(t, environment.TerraformFolder)
 
 		terraform.Destroy(t, terraformOptions)
+
+		DeleteResourceGroup(t, credential, environment.SubscriptionID, *externalResources.ResourceGroup.Name)
 	})
 
 	// Setup stage

--- a/tests/end-to-end-tests/terraform_output_test.go
+++ b/tests/end-to-end-tests/terraform_output_test.go
@@ -62,6 +62,8 @@ func TestTerraformOutput(t *testing.T) {
 		terraformOptions := test_structure.LoadTerraformOptions(t, environment.TerraformFolder)
 
 		terraform.Destroy(t, terraformOptions)
+
+		DeleteResourceGroup(t, credential, environment.SubscriptionID, *externalResources.ResourceGroup.Name)
 	})
 
 	// Setup stage


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Use the following icons: Checked ✅ / Unchecked: 🔲 -->

## Description

Following recent work to mandate log analytics, end to end tests were updated to create the resources necessary for the tests to run.

The clean up step was not added to some tests, resulting in dirty laundry being left in the end to end test subscription.

## Type of change

Please check the relevant options:

🔲 New feature (a change which adds functionality)
🔲 Bug fix (a change which fixes an issue)
🔲 Refactoring (code cleanup or optimisation)
✅ Testing (new tests, or improvements to existing tests)
🔲 Pipelines (changes to pipelines and workflows)
🔲 Documentation (changes to documentation)
🔲 Other (something that's not listed here - please explain)

## Checklist

Please check the relevant options:

✅ My code aligns with the style of this project
✅ I have added comments in hard to understand areas
✅ I have added tests that prove my change works
🔲 I have updated the documentation
✅ If merging into main, I'm aware that the PR should be squash merged with [a commit message that adheres to the semantic release format](https://github.com/semantic-release/semantic-release/tree/master?tab=readme-ov-file#commit-message-format)

## Additional Information

Please provide any additional information or context related to this pull request.
